### PR TITLE
Avoid duplicate declaration of the module headers.

### DIFF
--- a/manifests/mod/headers.pp
+++ b/manifests/mod/headers.pp
@@ -1,3 +1,5 @@
 class apache::mod::headers {
-  ::apache::mod { 'headers': }
+  if ! defined(Apache::Mod['headers']){
+    ::apache::mod { 'headers': }
+  }
 }


### PR DESCRIPTION
Avoid duplicate declaration of the apache module headers.
This is the case when the module is also declared in a user defined manifest that uses the puppetlabs-apache module.